### PR TITLE
Import google fonts using HTTPS

### DIFF
--- a/assets/styles/common/_global.scss
+++ b/assets/styles/common/_global.scss
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Cardo:400,400italic,700");
+@import url("https://fonts.googleapis.com/css?family=Cardo:400,400italic,700");
 
 body {
    font-family: $font-family-serif;


### PR DESCRIPTION
Stops browser complaints over mixed content.

Not doing the protocol relative option since HTTPS is available (http://www.paulirish.com/2010/the-protocol-relative-url/).
